### PR TITLE
Implement basic catalog, product and auth views

### DIFF
--- a/shop/views.py
+++ b/shop/views.py
@@ -1,5 +1,6 @@
-from django.http import Http404
 from django.shortcuts import render, get_object_or_404, redirect
+from django.contrib.auth import login, authenticate
+from user.forms import RegistrationForm, LoginForm
 
 from shop.models import Product, Cart, CartItem, Order, OrderItem
 
@@ -56,19 +57,37 @@ def main_page(request):
 
 # Каталог
 def catalog(request):
-    return render(request, "catalog.html")
+    products = Product.objects.all().order_by('name')
+    return render(request, "catalog.html", {"products": products})
 
 
 def product_detail(request, product_id):
-    return render(request, "product_detail.html")
+    product = get_object_or_404(Product, id=product_id)
+    return render(request, "product_detail.html", {"product": product})
 
 
 def auth(request):
-    return render(request, "auth.html")
+    if request.method == "POST":
+        form = LoginForm(request, data=request.POST)
+        if form.is_valid():
+            login(request, form.get_user())
+            return redirect("catalog")
+    else:
+        form = LoginForm()
+    return render(request, "auth.html", {"form": form})
 
 
 def registration(request):
-    return render(request, "registration.html")
+    if request.method == "POST":
+        form = RegistrationForm(request.POST)
+        if form.is_valid():
+            user = form.save()
+            Cart.objects.create(user_id=user)
+            login(request, user)
+            return redirect("catalog")
+    else:
+        form = RegistrationForm()
+    return render(request, "registration.html", {"form": form})
 
 
 # Линый кабинет

--- a/templates/auth.html
+++ b/templates/auth.html
@@ -34,9 +34,13 @@
     <p class="text-symbol1">Зарегистрироваться</p>
   </div>
 
-  <input class="input-symbol" value="Номер телефона" />
-  <input class="input-symbol" value="Пароль" />
-  <button class="btn-symbol-c btn3 hover-fx">Войти</button>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.non_field_errors }}
+    {{ form.username }}
+    {{ form.password }}
+    <button type="submit" class="btn-symbol-c btn3 hover-fx">Войти</button>
+  </form>
   <p class="text-symbol2">Не помню пароль</p>
 
   <footer class="footer-b footer1">

--- a/templates/catalog.html
+++ b/templates/catalog.html
@@ -111,60 +111,19 @@
 <button class="btn-symbol-a btn-symbol2 hover-fx">Показать</button>
 
 <div class="column-d col7">
-    <div class="column-row">
-        <div class="card-b card2">
-            <div class="card-circle-white-top2 circle-white2">
-                <object data="{% static 'assets/card-circle-white/card-heroicons.svg' %}"
-                        class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
-            </div>
-            <div class="card-circle-white-bottom">
-                <object data="{% static 'assets/circle-white/circle-white-heroicons2.svg' %}"
-                        class="card-heroicons-solid-heart card-heroicons3" type="image/svg+xml"></object>
-            </div>
+    <div class="product-list">
+        {% for product in products %}
+        <div class="product">
+            {% if product.image %}
+            <img src="{{ product.image.url }}" alt="{{ product.name }}" style="max-width: 150px;">
+            {% endif %}
+            <p>{{ product.name }}</p>
+            <p>{{ product.price }} ₽</p>
+            <a href="{% url 'product_detail' product.id %}">Подробнее</a>
         </div>
-        <div class="card-b card3">
-            <div class="card-circle-white-top2 circle-white2">
-                <object data="{% static 'assets/card-circle-white/card-heroicons.svg' %}"
-                        class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
-            </div>
-            <div class="card-circle-white-bottom">
-                <object data="{% static 'assets/circle-white/circle-white-heroicons2.svg' %}"
-                        class="card-heroicons-solid-heart card-heroicons3" type="image/svg+xml"></object>
-            </div>
-        </div>
-        <div class="card-b card4">
-            <div class="card-circle-white-top2 circle-white2">
-                <object data="{% static 'assets/card-circle-white/card-heroicons.svg' %}"
-                        class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
-            </div>
-            <div class="card-circle-white-bottom">
-                <object data="{% static 'assets/circle-white/circle-white-heroicons2.svg' %}"
-                        class="card-heroicons-solid-heart card-heroicons3" type="image/svg+xml"></object>
-            </div>
-        </div>
-    </div>
-    <div class="column-row-bottom1">
-        <div class="column-e col1">
-            <p>
-                Подарочный набор<br/>
-                «Антрацит»
-            </p>
-            <button class="btn-a column-btn2 hover-fx">8 775 ₽</button>
-        </div>
-        <div class="column-e col2">
-            <p>
-                Подарочный набор<br/>
-                «Улыбайся чаще»
-            </p>
-            <button class="btn-a column-btn2 hover-fx">5 544 ₽</button>
-        </div>
-        <div class="column-e col3">
-            <p>
-                Подарочный набор<br/>
-                «Красота-это ты!»
-            </p>
-            <button class="btn-a column-btn2 hover-fx">4 900 ₽</button>
-        </div>
+        {% empty %}
+        <p>Нет доступных продуктов.</p>
+        {% endfor %}
     </div>
 </div>
 

--- a/templates/product_detail.html
+++ b/templates/product_detail.html
@@ -27,9 +27,11 @@
   <object data="{% static 'assets/header-heroicons-216.svg' %}" class="heroicons-solid-heart-a heroicons-solid-heart1" type="image/svg+xml"></object>
   <object data="{% static 'assets/header-graphic.svg' %}" class="graphic1" type="image/svg+xml"></object>
   <p class="text-plus text3">+7 (495) 488-72-72</p>
-  <img src="{% static 'assets/symbol.png' %}" class="symbol7 box3" />
-  <h1 class="title-symbol title-black">Подарочный набор «Улыбайся чаще»</h1>
-  <h1 class="title2 title-black">23 510 ₽</h1>
+  {% if product.image %}
+  <img src="{{ product.image.url }}" class="symbol7 box3" />
+  {% endif %}
+  <h1 class="title-symbol title-black">{{ product.name }}</h1>
+  <h1 class="title2 title-black">{{ product.price }} ₽</h1>
 
   <div class="card-c card7">
     <p class="text-symbol-b">В избранное</p>
@@ -59,12 +61,7 @@
     <object data="{% static 'assets/symbol/row/row-heroicons.svg' %}" class="row-heroicons-solid-chevron row-heroicons2" type="image/svg+xml"></object>
   </div>
 
-  <p class="text-symbol1 text-gray1">
-    фарфоровая кружка ручной работы "Улыбайся чаще"  (возможно брендирование или своя надпись, цвет и модель –  в зависимости от сроков и тиражей);
-  </p>
-  <p class="text-symbol2 text-gray1">весенний хлопковый палантин;</p>
-  <p class="text-symbol3 text-gray1">суккулент;</p>
-  <p class="text-symbol4 text-gray1">коробка из дизайнерского картона 25х25.</p>
+  <p class="text-symbol1 text-gray1">{{ product.description }}</p>
   <div class="line-b line2"></div>
 
   <div class="row-c row3">

--- a/templates/registration.html
+++ b/templates/registration.html
@@ -34,11 +34,17 @@
     <button class="btn-symbol1 text5 hover-fx">Зарегистрироваться</button>
   </div>
 
-  <input class="input-symbol input-symbol1" value="Имя" />
-  <input class="input-symbol input-symbol2" value="Фамилия" />
-  <input class="input-symbol input-email" value="Email" />
-  <input class="input-symbol input-symbol3" value="Пароль" />
-  <button class="btn-symbol-c btn-symbol2 hover-fx">Зарегистрироваться</button>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.non_field_errors }}
+    {{ form.username }}
+    {{ form.first_name }}
+    {{ form.last_name }}
+    {{ form.email }}
+    {{ form.password1 }}
+    {{ form.password2 }}
+    <button type="submit" class="btn-symbol-c btn-symbol2 hover-fx">Зарегистрироваться</button>
+  </form>
   <p class="text6 text-gray3">
     Данные формы обрабатываются на основании <a class="link2" href="#">пользовательского соглашения</a>
   </p>

--- a/user/forms.py
+++ b/user/forms.py
@@ -1,0 +1,31 @@
+from django import forms
+from django.contrib.auth.forms import UserCreationForm, AuthenticationForm
+from django.contrib.auth.models import User
+
+class RegistrationForm(UserCreationForm):
+    first_name = forms.CharField(max_length=150, required=False,
+                                 widget=forms.TextInput(attrs={"class": "input-symbol input-symbol1"}))
+    last_name = forms.CharField(max_length=150, required=False,
+                                widget=forms.TextInput(attrs={"class": "input-symbol input-symbol2"}))
+    email = forms.EmailField(required=True,
+                             widget=forms.EmailInput(attrs={"class": "input-symbol input-email"}))
+
+    class Meta:
+        model = User
+        fields = (
+            "username",
+            "first_name",
+            "last_name",
+            "email",
+            "password1",
+            "password2",
+        )
+        widgets = {
+            "username": forms.TextInput(attrs={"class": "input-symbol"}),
+            "password1": forms.PasswordInput(attrs={"class": "input-symbol input-symbol3"}),
+            "password2": forms.PasswordInput(attrs={"class": "input-symbol"}),
+        }
+
+class LoginForm(AuthenticationForm):
+    username = forms.CharField(widget=forms.TextInput(attrs={"class": "input-symbol"}))
+    password = forms.CharField(widget=forms.PasswordInput(attrs={"class": "input-symbol"}))


### PR DESCRIPTION
## Summary
- add user forms for login and registration
- implement catalog, product detail, login and registration views
- inject forms into `auth.html` and `registration.html`
- display products dynamically on catalog and detail pages

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684b287843cc832a9cf5cf158ce15903