### PR TITLE
Add navigation base template

### DIFF
--- a/shop/static/css/base.css
+++ b/shop/static/css/base.css
@@ -1,0 +1,14 @@
+.main-nav, .footer-nav {
+    display: flex;
+    gap: 10px;
+    padding: 10px 0;
+}
+
+.main-nav a, .footer-nav a {
+    text-decoration: none;
+    color: #333;
+}
+
+.main-nav a:hover, .footer-nav a:hover {
+    text-decoration: underline;
+}

--- a/templates/auth.html
+++ b/templates/auth.html
@@ -1,17 +1,8 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-
-  {% load static %}
-  <link rel="stylesheet" href="{% static 'css/reset.css' %}" />
-  <link rel="stylesheet" href="{% static 'css/fonts.css' %}" />
-  <link rel="stylesheet" href="{% static 'css/global.css' %}" />
-  <link rel="stylesheet" href="{% static 'css/desktop7.css' %}" />
-</head>
-
-<body>
+{% extends 'base.html' %}
+{% load static %}
+{% block title %}Авторизация{% endblock %}
+{% block content %}
+<link rel="stylesheet" href="{% static 'css/desktop7.css' %}">
   <div class="row-a row1">
     <object data="{% static 'assets/row/row-graphic.svg' %}" class="row-graphic" type="image/svg+xml"></object>
     <p class="row-text1">Поиск по каталогу</p>
@@ -62,5 +53,4 @@
       <p class="nav-items-text-symbol">Доставка</p>
     </div>
   </footer>
-</body>
-</html>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,37 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <title>{% block title %}Set Present{% endblock %}</title>
+    <link rel="stylesheet" href="{% static 'css/reset.css' %}" />
+    <link rel="stylesheet" href="{% static 'css/fonts.css' %}" />
+    <link rel="stylesheet" href="{% static 'css/global.css' %}" />
+    <link rel="stylesheet" href="{% static 'css/base.css' %}" />
+</head>
+<body>
+<header>
+    <nav class="main-nav">
+        <a href="{% url 'main_page' %}">Главная</a>
+        <a href="{% url 'catalog' %}">Каталог</a>
+        <a href="{% url 'cart' %}">Корзина</a>
+        <a href="{% url 'favourites' %}">Избранное</a>
+        <a href="{% url 'profile' %}">Профиль</a>
+        <a href="{% url 'auth' %}">Вход</a>
+        <a href="{% url 'registration' %}">Регистрация</a>
+    </nav>
+</header>
+<main>
+{% block content %}{% endblock %}
+</main>
+<footer>
+    <nav class="footer-nav">
+        <a href="{% url 'main_page' %}">Главная</a>
+        <a href="{% url 'catalog' %}">Каталог</a>
+        <a href="{% url 'cart' %}">Корзина</a>
+        <a href="{% url 'favourites' %}">Избранное</a>
+    </nav>
+</footer>
+</body>
+</html>

--- a/templates/cart.html
+++ b/templates/cart.html
@@ -1,17 +1,8 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-
-  {% load static %}
-  <link rel="stylesheet" href="{% static 'css/reset.css' %}" />
-  <link rel="stylesheet" href="{% static 'css/fonts.css' %}" />
-  <link rel="stylesheet" href="{% static 'css/global.css' %}" />
-  <link rel="stylesheet" href="{% static 'css/symbol4.css' %}" />
-</head>
-
-<body>
+{% extends 'base.html' %}
+{% load static %}
+{% block title %}Корзина{% endblock %}
+{% block content %}
+<link rel="stylesheet" href="{% static 'css/symbol4.css' %}">
   <div class="group-c group1">
     <object data="{% static 'assets/btn-icon.svg' %}" class="heroicons-solid-heart-a group-heroicons1" type="image/svg+xml"></object>
   </div>
@@ -142,5 +133,4 @@
       <p class="nav-items-text-symbol">Доставка</p>
     </div>
   </footer>
-</body>
-</html>
+{% endblock %}

--- a/templates/catalog.html
+++ b/templates/catalog.html
@@ -1,17 +1,8 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-
-    {% load static %}
-    <link rel="stylesheet" href="{% static 'css/reset.css' %}"/>
-    <link rel="stylesheet" href="{% static 'css/fonts.css' %}"/>
-    <link rel="stylesheet" href="{% static 'css/global.css' %}"/>
-    <link rel="stylesheet" href="{% static 'css/desktop1.css' %}"/>
-</head>
-
-<body>
+{% extends 'base.html' %}
+{% load static %}
+{% block title %}Каталог{% endblock %}
+{% block content %}
+<link rel="stylesheet" href="{% static 'css/desktop1.css' %}">
 <div class="row-a row1">
     <object data="{% static 'assets/row/row-graphic.svg' %}" class="row-graphic" type="image/svg+xml"></object>
     <p class="row-text1">Поиск по каталогу</p>
@@ -150,5 +141,4 @@
         <p class="nav-items-text-symbol">Доставка</p>
     </div>
 </footer>
-</body>
-</html>
+{% endblock %}

--- a/templates/favourites.html
+++ b/templates/favourites.html
@@ -1,17 +1,8 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-
-  {% load static %}
-  <link rel="stylesheet" href="{% static 'css/reset.css' %}" />
-  <link rel="stylesheet" href="{% static 'css/fonts.css' %}" />
-  <link rel="stylesheet" href="{% static 'css/global.css' %}" />
-  <link rel="stylesheet" href="{% static 'css/desktop5.css' %}" />
-</head>
-
-<body>
+{% extends 'base.html' %}
+{% load static %}
+{% block title %}Избранное{% endblock %}
+{% block content %}
+<link rel="stylesheet" href="{% static 'css/desktop5.css' %}">
   <div class="group-c group1">
     <object data="{% static 'assets/btn-icon.svg' %}" class="heroicons-solid-heart-a group-heroicons1" type="image/svg+xml"></object>
   </div>
@@ -115,5 +106,4 @@
       <p class="nav-items-text-symbol">Доставка</p>
     </div>
   </footer>
-</body>
-</html>
+{% endblock %}

--- a/templates/mainpage.html
+++ b/templates/mainpage.html
@@ -1,17 +1,8 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-
-  {% load static %}
-  <link rel="stylesheet" href="{% static 'css/reset.css' %}" />
-  <link rel="stylesheet" href="{% static 'css/fonts.css' %}" />
-  <link rel="stylesheet" href="{% static 'css/global.css' %}" />
-  <link rel="stylesheet" href="{% static 'css/mainpage.css' %}" />
-</head>
-
-<body>
+{% extends 'base.html' %}
+{% load static %}
+{% block title %}Главная{% endblock %}
+{% block content %}
+<link rel="stylesheet" href="{% static 'css/mainpage.css' %}">
   <header class="header">
     <div class="header-group1">
       <p class="header-text">+7 (495) 488-72-72</p>
@@ -134,5 +125,4 @@
       <p class="nav-items-text-symbol">Доставка</p>
     </div>
   </footer>
-</body>
-</html>
+{% endblock %}

--- a/templates/product_detail.html
+++ b/templates/product_detail.html
@@ -1,17 +1,8 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-
-  {% load static %}
-  <link rel="stylesheet" href="{% static 'css/reset.css' %}" />
-  <link rel="stylesheet" href="{% static 'css/fonts.css' %}" />
-  <link rel="stylesheet" href="{% static 'css/global.css' %}" />
-  <link rel="stylesheet" href="{% static 'css/symbol2.css' %}" />
-</head>
-
-<body>
+{% extends 'base.html' %}
+{% load static %}
+{% block title %}{{ product.name }}{% endblock %}
+{% block content %}
+<link rel="stylesheet" href="{% static 'css/symbol2.css' %}">
   <div class="group-c group1">
     <object data="{% static 'assets/btn-icon.svg' %}" class="heroicons-solid-heart-a group-heroicons1" type="image/svg+xml"></object>
   </div>
@@ -172,5 +163,4 @@
       <p class="nav-items-text-symbol">Доставка</p>
     </div>
   </footer>
-</body>
-</html>
+{% endblock %}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -1,17 +1,8 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-
-  {% load static %}
-  <link rel="stylesheet" href="{% static 'css/reset.css' %}" />
-  <link rel="stylesheet" href="{% static 'css/fonts.css' %}" />
-  <link rel="stylesheet" href="{% static 'css/global.css' %}" />
-  <link rel="stylesheet" href="{% static 'css/desktop6.css' %}" />
-</head>
-
-<body>
+{% extends 'base.html' %}
+{% load static %}
+{% block title %}Профиль{% endblock %}
+{% block content %}
+<link rel="stylesheet" href="{% static 'css/desktop6.css' %}">
   <div class="group1 btn1">
     <object data="{% static 'assets/btn-icon.svg' %}" class="heroicons-solid-heart-b heroicons-outline-phone" type="image/svg+xml"></object>
   </div>
@@ -201,5 +192,4 @@
       <p class="nav-items-text-symbol">Доставка</p>
     </div>
   </footer>
-</body>
-</html>
+{% endblock %}

--- a/templates/registration.html
+++ b/templates/registration.html
@@ -1,17 +1,8 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-
-  {% load static %}
-  <link rel="stylesheet" href="{% static 'css/reset.css' %}" />
-  <link rel="stylesheet" href="{% static 'css/fonts.css' %}" />
-  <link rel="stylesheet" href="{% static 'css/global.css' %}" />
-  <link rel="stylesheet" href="{% static 'css/symbol5.css' %}" />
-</head>
-
-<body>
+{% extends 'base.html' %}
+{% load static %}
+{% block title %}Регистрация{% endblock %}
+{% block content %}
+<link rel="stylesheet" href="{% static 'css/symbol5.css' %}">
   <div class="row-a row1">
     <object data="{% static 'assets/row/row-graphic.svg' %}" class="row-graphic" type="image/svg+xml"></object>
     <p class="row-text1">Поиск по каталогу</p>
@@ -68,5 +59,4 @@
       <p class="nav-items-text-symbol">Доставка</p>
     </div>
   </footer>
-</body>
-</html>
+{% endblock %}

--- a/templates/shop/checkout.html
+++ b/templates/shop/checkout.html
@@ -1,9 +1,6 @@
-<!DOCTYPE html>
-<html lang="ru">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Оформление заказа</title>
+{% extends 'base.html' %}
+{% block title %}Оформление заказа{% endblock %}
+{% block content %}
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -36,7 +33,6 @@
         }
     </style>
 </head>
-<body>
     <h1>Оформление заказа</h1>
     <form action="{% url 'checkout' %}" method="post">
         {% csrf_token %}
@@ -68,5 +64,4 @@
         <button type="submit" class="button">Подтвердить заказ</button>
     </form>
     <a class="button" href="{% url 'view_cart' %}">Назад в корзину</a>
-</body>
-</html>
+{% endblock %}

--- a/templates/shop/index.html
+++ b/templates/shop/index.html
@@ -1,9 +1,6 @@
-<!DOCTYPE html>
-<html lang="ru">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Список продуктов</title>
+{% extends 'base.html' %}
+{% block title %}Список продуктов{% endblock %}
+{% block content %}
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -42,7 +39,6 @@
         }
     </style>
 </head>
-<body>
     <h1>Список продуктов</h1>
     <div class="product-list">
         {% for product in products %}
@@ -61,5 +57,4 @@
             <p>Нет доступных продуктов.</p>
         {% endfor %}
     </div>
-</body>
-</html>
+{% endblock %}

--- a/templates/shop/product_detail.html
+++ b/templates/shop/product_detail.html
@@ -1,11 +1,6 @@
-<!DOCTYPE html>
-<html lang="ru">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ product.name }}</title>
-</head>
-<body>
+{% extends 'base.html' %}
+{% block title %}{{ product.name }}{% endblock %}
+{% block content %}
     <h1>{{ product.name }}</h1>
     <img src="{{ product.image.url }}" alt="{{ product.name }}" style="width: 300px; height: auto;">
     <p>{{ product.description }}</p>
@@ -16,5 +11,4 @@
         <button type="submit">Добавить в корзину</button>
     </form>
     <a href="{% url 'shop' %}">Назад к списку продуктов</a>
-</body>
-</html>
+{% endblock %}

--- a/templates/shop/view_cart.html
+++ b/templates/shop/view_cart.html
@@ -1,11 +1,7 @@
+{% extends 'base.html' %}
 {% load cart_tags %}
-<!DOCTYPE html>
-<html lang="ru">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Корзина</title>
-    <style>
+{% block title %}Корзина{% endblock %}
+{% block content %}
         body {
             font-family: Arial, sans-serif;
             margin: 20px;
@@ -40,7 +36,6 @@
         }
     </style>
 </head>
-<body>
     <h1>Корзина</h1>
     <ul>
         {% if cart_items %}
@@ -63,5 +58,4 @@
     </ul>
     <a class="button" href="{% url 'checkout' %}">Оформить заказ</a>
     <a class="button" href="{% url 'shop' %}">Назад к списку продуктов</a>
-</body>
-</html>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create shared `base.html` with navigation links
- centralize layout styles in new `base.css`
- update all templates to extend the base layout

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684b2e97cf78832a8ac6330f0da4efad