### PR TITLE
Fix style conflicts and improve slider

### DIFF
--- a/shop/static/css/base.css
+++ b/shop/static/css/base.css
@@ -54,3 +54,7 @@
     border: none;
     padding: 10px;
 }
+.slider-icon {
+    width: 30px;
+    height: 30px;
+}

--- a/templates/auth.html
+++ b/templates/auth.html
@@ -1,8 +1,11 @@
 {% extends 'base.html' %}
 {% load static %}
 {% block title %}Авторизация{% endblock %}
-{% block content %}
+{% block extra_css %}
 <link rel="stylesheet" href="{% static 'css/desktop7.css' %}">
+{% endblock %}
+{% block body_class %}auth-page{% endblock %}
+{% block content %}
   <div class="row-a row1">
     <object data="{% static 'assets/row/row-graphic.svg' %}" class="row-graphic" type="image/svg+xml"></object>
     <p class="row-text1">Поиск по каталогу</p>

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,8 +9,9 @@
     <link rel="stylesheet" href="{% static 'css/fonts.css' %}" />
     <link rel="stylesheet" href="{% static 'css/global.css' %}" />
     <link rel="stylesheet" href="{% static 'css/base.css' %}" />
+    {% block extra_css %}{% endblock %}
 </head>
-<body>
+<body class="{% block body_class %}{% endblock %}">
 <div id="sideNav" class="side-nav">
     <a href="javascript:void(0)" class="closebtn" onclick="closeNav()">&times;</a>
     <a href="{% url 'main_page' %}">Главная</a>
@@ -23,7 +24,7 @@
 </div>
 
 <header>
-    <button class="menu-button" onclick="openNav()">&#9776;</button>
+    <img src="{% static 'assets/btn-icon.svg' %}" alt="menu" class="menu-button slider-icon" onclick="openNav()" />
 </header>
 <main>
 {% block content %}{% endblock %}

--- a/templates/cart.html
+++ b/templates/cart.html
@@ -1,8 +1,11 @@
 {% extends 'base.html' %}
 {% load static %}
 {% block title %}Корзина{% endblock %}
-{% block content %}
+{% block extra_css %}
 <link rel="stylesheet" href="{% static 'css/symbol4.css' %}">
+{% endblock %}
+{% block body_class %}cart-page{% endblock %}
+{% block content %}
   <div class="group-c group1">
     <object data="{% static 'assets/btn-icon.svg' %}" class="heroicons-solid-heart-a group-heroicons1" type="image/svg+xml"></object>
   </div>

--- a/templates/catalog.html
+++ b/templates/catalog.html
@@ -1,8 +1,11 @@
 {% extends 'base.html' %}
 {% load static %}
 {% block title %}Каталог{% endblock %}
-{% block content %}
+{% block extra_css %}
 <link rel="stylesheet" href="{% static 'css/desktop1.css' %}">
+{% endblock %}
+{% block body_class %}catalog-page{% endblock %}
+{% block content %}
 <div class="row-a row1">
     <object data="{% static 'assets/row/row-graphic.svg' %}" class="row-graphic" type="image/svg+xml"></object>
     <p class="row-text1">Поиск по каталогу</p>

--- a/templates/favourites.html
+++ b/templates/favourites.html
@@ -1,8 +1,11 @@
 {% extends 'base.html' %}
 {% load static %}
 {% block title %}Избранное{% endblock %}
-{% block content %}
+{% block extra_css %}
 <link rel="stylesheet" href="{% static 'css/desktop5.css' %}">
+{% endblock %}
+{% block body_class %}favourites-page{% endblock %}
+{% block content %}
   <div class="group-c group1">
     <object data="{% static 'assets/btn-icon.svg' %}" class="heroicons-solid-heart-a group-heroicons1" type="image/svg+xml"></object>
   </div>

--- a/templates/mainpage.html
+++ b/templates/mainpage.html
@@ -1,8 +1,11 @@
 {% extends 'base.html' %}
 {% load static %}
 {% block title %}Главная{% endblock %}
-{% block content %}
+{% block extra_css %}
 <link rel="stylesheet" href="{% static 'css/mainpage.css' %}">
+{% endblock %}
+{% block body_class %}mainpage{% endblock %}
+{% block content %}
   <header class="header">
     <div class="header-group1">
       <p class="header-text">+7 (495) 488-72-72</p>

--- a/templates/product_detail.html
+++ b/templates/product_detail.html
@@ -1,8 +1,11 @@
 {% extends 'base.html' %}
 {% load static %}
 {% block title %}{{ product.name }}{% endblock %}
-{% block content %}
+{% block extra_css %}
 <link rel="stylesheet" href="{% static 'css/symbol2.css' %}">
+{% endblock %}
+{% block body_class %}product-page{% endblock %}
+{% block content %}
   <div class="group-c group1">
     <object data="{% static 'assets/btn-icon.svg' %}" class="heroicons-solid-heart-a group-heroicons1" type="image/svg+xml"></object>
   </div>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -1,8 +1,11 @@
 {% extends 'base.html' %}
 {% load static %}
 {% block title %}Профиль{% endblock %}
-{% block content %}
+{% block extra_css %}
 <link rel="stylesheet" href="{% static 'css/desktop6.css' %}">
+{% endblock %}
+{% block body_class %}profile-page{% endblock %}
+{% block content %}
   <div class="group1 btn1">
     <object data="{% static 'assets/btn-icon.svg' %}" class="heroicons-solid-heart-b heroicons-outline-phone" type="image/svg+xml"></object>
   </div>

--- a/templates/registration.html
+++ b/templates/registration.html
@@ -1,8 +1,11 @@
 {% extends 'base.html' %}
 {% load static %}
 {% block title %}Регистрация{% endblock %}
-{% block content %}
+{% block extra_css %}
 <link rel="stylesheet" href="{% static 'css/symbol5.css' %}">
+{% endblock %}
+{% block body_class %}registration-page{% endblock %}
+{% block content %}
   <div class="row-a row1">
     <object data="{% static 'assets/row/row-graphic.svg' %}" class="row-graphic" type="image/svg+xml"></object>
     <p class="row-text1">Поиск по каталогу</p>


### PR DESCRIPTION
## Summary
- isolate page styles via `extra_css` block
- add `body_class` block in base template
- convert menu button to icon slider on the left
- style slider icon in base CSS

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684fe6d8fdf0832a80b48855d94b9085