### PR TITLE
Enable page-specific static asset imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .venv
 db.sqlite3
 
-products
+*.pyc
+
+__pycache__/

--- a/templates/catalog2.html
+++ b/templates/catalog2.html
@@ -1,33 +1,34 @@
+{% load static %}
 <!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 	<link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap" rel="stylesheet">
-	<link rel="stylesheet" href="css/reset.css" />
-	<link rel="stylesheet" href="css/global.css" />
-	<link rel="stylesheet" href="css/desktop.css" />
+	<link rel="stylesheet" href="{% static 'каталог/css/reset.css' %}" />
+	<link rel="stylesheet" href="{% static 'каталог/css/global.css' %}" />
+	<link rel="stylesheet" href="{% static 'каталог/css/desktop.css' %}" />
 
 </head>
 
 <body>
 	<div class="row-top1">
 		<p class="text-plus">+7 (495) 488-72-72</p>
-		<object data="assets/graphic1.svg" class="graphic-left1" type="image/svg+xml"></object>
+		<object data="{% static 'каталог/assets/graphic1.svg' %}" class="graphic-left1" type="image/svg+xml"></object>
 		<h2 class="subtitle-set-present">set present</h2>
 		
 		<div class="row1">
-			<object data="assets/graphic2.svg" class="graphic-left2" type="image/svg+xml"></object>
+			<object data="{% static 'каталог/assets/graphic2.svg' %}" class="graphic-left2" type="image/svg+xml"></object>
 			<p class="text-symbol1">Поиск по каталогу</p>
 		</div>
 		
 		<div class="group1">
-			<object data="assets/heroicons-outline-phone.svg" class="heroicons-outline-phone" type="image/svg+xml"></object>
+			<object data="{% static 'каталог/assets/heroicons-outline-phone.svg' %}" class="heroicons-outline-phone" type="image/svg+xml"></object>
 		</div>
 		
-		<object data="assets/heroicons-solid-heart.svg" class="heroicons-solid-user heroicons-solid-heart" type="image/svg+xml"></object>
-		<object data="assets/heroicons.svg" class="heroicons-solid-user heroicons" type="image/svg+xml"></object>
-		<object data="assets/heroicons-solid-user.svg" class="heroicons-solid-user heroicons-solid-user1" type="image/svg+xml"></object>
+		<object data="{% static 'каталог/assets/heroicons-solid-heart.svg' %}" class="heroicons-solid-user heroicons-solid-heart" type="image/svg+xml"></object>
+		<object data="{% static 'каталог/assets/heroicons.svg' %}" class="heroicons-solid-user heroicons" type="image/svg+xml"></object>
+		<object data="{% static 'каталог/assets/heroicons-solid-user.svg' %}" class="heroicons-solid-user heroicons-solid-user1" type="image/svg+xml"></object>
 	</div>
 	
 	<div class="col4">
@@ -36,17 +37,17 @@
 			
 			<button class="frame btn1 hover-dark">
 				<p>По популярности</p>
-				<object data="assets/frame/frame-icon.svg" class="frame-heroicons-solid-chevron frame-icon" type="image/svg+xml"></object>
+				<object data="{% static 'каталог/assets/frame/frame-icon.svg' %}" class="frame-heroicons-solid-chevron frame-icon" type="image/svg+xml"></object>
 			</button>
 			
 			<button class="frame btn2 hover-dark">
 				<p>По алфавиту</p>
-				<object data="assets/frame/frame-icon.svg" class="frame-heroicons-solid-chevron frame-icon" type="image/svg+xml"></object>
+				<object data="{% static 'каталог/assets/frame/frame-icon.svg' %}" class="frame-heroicons-solid-chevron frame-icon" type="image/svg+xml"></object>
 			</button>
 			
 			<div class="frame frame1">
 				<p>По цене</p>
-				<object data="assets/frame/frame-icon.svg" class="frame-heroicons-solid-chevron frame-icon" type="image/svg+xml"></object>
+				<object data="{% static 'каталог/assets/frame/frame-icon.svg' %}" class="frame-heroicons-solid-chevron frame-icon" type="image/svg+xml"></object>
 			</div>
 		</div>
 		
@@ -85,11 +86,11 @@
 						<div class="column col1">
 							<div class="card">
 								<div class="card-circle-white-top circle">
-									<object data="assets/card-circle-white/card-heroicons.svg" class="card-heroicons-solid-heart card-heroicons1" type="image/svg+xml"></object>
+									<object data="{% static 'каталог/assets/card-circle-white/card-heroicons.svg' %}" class="card-heroicons-solid-heart card-heroicons1" type="image/svg+xml"></object>
 								</div>
 								
 								<div class="card-circle-white-bottom">
-									<object data="assets/card-circle-white/card-heroicons2.svg" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
+									<object data="{% static 'каталог/assets/card-circle-white/card-heroicons2.svg' %}" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
 								</div>
 							</div>
 							
@@ -105,11 +106,11 @@
 						<div class="column col2">
 							<div class="card">
 								<div class="card-circle-white-top circle">
-									<object data="assets/card-circle-white/card-heroicons.svg" class="card-heroicons-solid-heart card-heroicons1" type="image/svg+xml"></object>
+									<object data="{% static 'каталог/assets/card-circle-white/card-heroicons.svg' %}" class="card-heroicons-solid-heart card-heroicons1" type="image/svg+xml"></object>
 								</div>
 								
 								<div class="card-circle-white-bottom">
-									<object data="assets/card-circle-white/card-heroicons2.svg" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
+									<object data="{% static 'каталог/assets/card-circle-white/card-heroicons2.svg' %}" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
 								</div>
 							</div>
 							
@@ -125,11 +126,11 @@
 						<div class="column col3">
 							<div class="card">
 								<div class="card-circle-white-top circle">
-									<object data="assets/card-circle-white/card-heroicons.svg" class="card-heroicons-solid-heart card-heroicons1" type="image/svg+xml"></object>
+									<object data="{% static 'каталог/assets/card-circle-white/card-heroicons.svg' %}" class="card-heroicons-solid-heart card-heroicons1" type="image/svg+xml"></object>
 								</div>
 								
 								<div class="card-circle-white-bottom">
-									<object data="assets/card-circle-white/card-heroicons2.svg" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
+									<object data="{% static 'каталог/assets/card-circle-white/card-heroicons2.svg' %}" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
 								</div>
 							</div>
 							
@@ -147,11 +148,11 @@
 						<div class="column col1">
 							<div class="card">
 								<div class="card-circle-white-top circle">
-									<object data="assets/card-circle-white/card-heroicons.svg" class="card-heroicons-solid-heart card-heroicons1" type="image/svg+xml"></object>
+									<object data="{% static 'каталог/assets/card-circle-white/card-heroicons.svg' %}" class="card-heroicons-solid-heart card-heroicons1" type="image/svg+xml"></object>
 								</div>
 								
 								<div class="card-circle-white-bottom">
-									<object data="assets/card-circle-white/card-heroicons2.svg" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
+									<object data="{% static 'каталог/assets/card-circle-white/card-heroicons2.svg' %}" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
 								</div>
 							</div>
 							
@@ -167,11 +168,11 @@
 						<div class="column col2">
 							<div class="card">
 								<div class="card-circle-white-top circle">
-									<object data="assets/card-circle-white/card-heroicons.svg" class="card-heroicons-solid-heart card-heroicons1" type="image/svg+xml"></object>
+									<object data="{% static 'каталог/assets/card-circle-white/card-heroicons.svg' %}" class="card-heroicons-solid-heart card-heroicons1" type="image/svg+xml"></object>
 								</div>
 								
 								<div class="card-circle-white-bottom">
-									<object data="assets/card-circle-white/card-heroicons2.svg" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
+									<object data="{% static 'каталог/assets/card-circle-white/card-heroicons2.svg' %}" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
 								</div>
 							</div>
 							
@@ -187,11 +188,11 @@
 						<div class="column col3">
 							<div class="card">
 								<div class="card-circle-white-top circle">
-									<object data="assets/card-circle-white/card-heroicons.svg" class="card-heroicons-solid-heart card-heroicons1" type="image/svg+xml"></object>
+									<object data="{% static 'каталог/assets/card-circle-white/card-heroicons.svg' %}" class="card-heroicons-solid-heart card-heroicons1" type="image/svg+xml"></object>
 								</div>
 								
 								<div class="card-circle-white-bottom">
-									<object data="assets/card-circle-white/card-heroicons2.svg" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
+									<object data="{% static 'каталог/assets/card-circle-white/card-heroicons2.svg' %}" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
 								</div>
 							</div>
 							
@@ -209,11 +210,11 @@
 						<div class="column col1">
 							<div class="card">
 								<div class="card-circle-white-top circle">
-									<object data="assets/card-circle-white/card-heroicons.svg" class="card-heroicons-solid-heart card-heroicons1" type="image/svg+xml"></object>
+									<object data="{% static 'каталог/assets/card-circle-white/card-heroicons.svg' %}" class="card-heroicons-solid-heart card-heroicons1" type="image/svg+xml"></object>
 								</div>
 								
 								<div class="card-circle-white-bottom">
-									<object data="assets/card-circle-white/card-heroicons2.svg" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
+									<object data="{% static 'каталог/assets/card-circle-white/card-heroicons2.svg' %}" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
 								</div>
 							</div>
 							
@@ -229,11 +230,11 @@
 						<div class="column col2">
 							<div class="card">
 								<div class="card-circle-white-top circle">
-									<object data="assets/card-circle-white/card-heroicons.svg" class="card-heroicons-solid-heart card-heroicons1" type="image/svg+xml"></object>
+									<object data="{% static 'каталог/assets/card-circle-white/card-heroicons.svg' %}" class="card-heroicons-solid-heart card-heroicons1" type="image/svg+xml"></object>
 								</div>
 								
 								<div class="card-circle-white-bottom">
-									<object data="assets/card-circle-white/card-heroicons2.svg" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
+									<object data="{% static 'каталог/assets/card-circle-white/card-heroicons2.svg' %}" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
 								</div>
 							</div>
 							
@@ -249,11 +250,11 @@
 						<div class="column col3">
 							<div class="card">
 								<div class="card-circle-white-top circle">
-									<object data="assets/card-circle-white/card-heroicons.svg" class="card-heroicons-solid-heart card-heroicons1" type="image/svg+xml"></object>
+									<object data="{% static 'каталог/assets/card-circle-white/card-heroicons.svg' %}" class="card-heroicons-solid-heart card-heroicons1" type="image/svg+xml"></object>
 								</div>
 								
 								<div class="card-circle-white-bottom">
-									<object data="assets/card-circle-white/card-heroicons2.svg" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
+									<object data="{% static 'каталог/assets/card-circle-white/card-heroicons2.svg' %}" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
 								</div>
 							</div>
 							
@@ -271,11 +272,11 @@
 						<div class="column col1">
 							<div class="card">
 								<div class="card-circle-white-top circle">
-									<object data="assets/card-circle-white/card-heroicons.svg" class="card-heroicons-solid-heart card-heroicons1" type="image/svg+xml"></object>
+									<object data="{% static 'каталог/assets/card-circle-white/card-heroicons.svg' %}" class="card-heroicons-solid-heart card-heroicons1" type="image/svg+xml"></object>
 								</div>
 								
 								<div class="card-circle-white-bottom">
-									<object data="assets/card-circle-white/card-heroicons2.svg" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
+									<object data="{% static 'каталог/assets/card-circle-white/card-heroicons2.svg' %}" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
 								</div>
 							</div>
 							
@@ -291,11 +292,11 @@
 						<div class="column col2">
 							<div class="card">
 								<div class="card-circle-white-top circle">
-									<object data="assets/card-circle-white/card-heroicons.svg" class="card-heroicons-solid-heart card-heroicons1" type="image/svg+xml"></object>
+									<object data="{% static 'каталог/assets/card-circle-white/card-heroicons.svg' %}" class="card-heroicons-solid-heart card-heroicons1" type="image/svg+xml"></object>
 								</div>
 								
 								<div class="card-circle-white-bottom">
-									<object data="assets/card-circle-white/card-heroicons2.svg" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
+									<object data="{% static 'каталог/assets/card-circle-white/card-heroicons2.svg' %}" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
 								</div>
 							</div>
 							
@@ -311,11 +312,11 @@
 						<div class="column col3">
 							<div class="card">
 								<div class="card-circle-white-top circle">
-									<object data="assets/card-circle-white/card-heroicons.svg" class="card-heroicons-solid-heart card-heroicons1" type="image/svg+xml"></object>
+									<object data="{% static 'каталог/assets/card-circle-white/card-heroicons.svg' %}" class="card-heroicons-solid-heart card-heroicons1" type="image/svg+xml"></object>
 								</div>
 								
 								<div class="card-circle-white-bottom">
-									<object data="assets/card-circle-white/card-heroicons2.svg" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
+									<object data="{% static 'каталог/assets/card-circle-white/card-heroicons2.svg' %}" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
 								</div>
 							</div>
 							
@@ -333,11 +334,11 @@
 						<div class="column col1">
 							<div class="card">
 								<div class="card-circle-white-top circle">
-									<object data="assets/card-circle-white/card-heroicons.svg" class="card-heroicons-solid-heart card-heroicons1" type="image/svg+xml"></object>
+									<object data="{% static 'каталог/assets/card-circle-white/card-heroicons.svg' %}" class="card-heroicons-solid-heart card-heroicons1" type="image/svg+xml"></object>
 								</div>
 								
 								<div class="card-circle-white-bottom">
-									<object data="assets/card-circle-white/card-heroicons2.svg" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
+									<object data="{% static 'каталог/assets/card-circle-white/card-heroicons2.svg' %}" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
 								</div>
 							</div>
 							
@@ -353,11 +354,11 @@
 						<div class="column col2">
 							<div class="card">
 								<div class="card-circle-white-top circle">
-									<object data="assets/card-circle-white/card-heroicons.svg" class="card-heroicons-solid-heart card-heroicons1" type="image/svg+xml"></object>
+									<object data="{% static 'каталог/assets/card-circle-white/card-heroicons.svg' %}" class="card-heroicons-solid-heart card-heroicons1" type="image/svg+xml"></object>
 								</div>
 								
 								<div class="card-circle-white-bottom">
-									<object data="assets/card-circle-white/card-heroicons2.svg" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
+									<object data="{% static 'каталог/assets/card-circle-white/card-heroicons2.svg' %}" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
 								</div>
 							</div>
 							
@@ -373,11 +374,11 @@
 						<div class="column col3">
 							<div class="card">
 								<div class="card-circle-white-top circle">
-									<object data="assets/card-circle-white/card-heroicons.svg" class="card-heroicons-solid-heart card-heroicons1" type="image/svg+xml"></object>
+									<object data="{% static 'каталог/assets/card-circle-white/card-heroicons.svg' %}" class="card-heroicons-solid-heart card-heroicons1" type="image/svg+xml"></object>
 								</div>
 								
 								<div class="card-circle-white-bottom">
-									<object data="assets/card-circle-white/card-heroicons2.svg" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
+									<object data="{% static 'каталог/assets/card-circle-white/card-heroicons2.svg' %}" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
 								</div>
 							</div>
 							
@@ -397,7 +398,7 @@
 				<p class="text-symbol2">Показать еще</p>
 				
 				<div class="circle-black-right">
-					<object data="assets/heroicons-solid-plus.svg" class="heroicons-solid-plus" type="image/svg+xml"></object>
+					<object data="{% static 'каталог/assets/heroicons-solid-plus.svg' %}" class="heroicons-solid-plus" type="image/svg+xml"></object>
 				</div>
 			</div>
 		</div>
@@ -414,11 +415,11 @@
 			
 			<div class="footer-nav-items1">
 				<div class="footer-circle circle">
-					<object data="assets/footer-graphic1.svg" class="footer-graphic1" type="image/svg+xml"></object>
+					<object data="{% static 'каталог/assets/footer-graphic1.svg' %}" class="footer-graphic1" type="image/svg+xml"></object>
 				</div>
 				
-				<object data="assets/footer-graphic2.svg" class="footer-graphic footer-graphic2" type="image/svg+xml"></object>
-				<object data="assets/footer-graphic3.svg" class="footer-graphic footer-graphic-right" type="image/svg+xml"></object>
+				<object data="{% static 'каталог/assets/footer-graphic2.svg' %}" class="footer-graphic footer-graphic2" type="image/svg+xml"></object>
+				<object data="{% static 'каталог/assets/footer-graphic3.svg' %}" class="footer-graphic footer-graphic-right" type="image/svg+xml"></object>
 			</div>
 		</div>
 		

--- a/templates/constructor.html
+++ b/templates/constructor.html
@@ -1,22 +1,23 @@
+{% load static %}
 <!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 	<link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap" rel="stylesheet">
-	<link rel="stylesheet" href="css/reset.css" />
-	<link rel="stylesheet" href="css/global.css" />
-	<link rel="stylesheet" href="css/symbol.css" />
+	<link rel="stylesheet" href="{% static 'конструктор стр1/css/reset.css' %}" />
+	<link rel="stylesheet" href="{% static 'конструктор стр1/css/global.css' %}" />
+	<link rel="stylesheet" href="{% static 'конструктор стр1/css/symbol.css' %}" />
 
 </head>
 
 <body>
 	<div class="row-top">
-		<object data="assets/graphic1.svg" class="graphic-left1" type="image/svg+xml"></object>
+		<object data="{% static 'конструктор стр1/assets/graphic1.svg' %}" class="graphic-left1" type="image/svg+xml"></object>
 		<button class="btn-set-present hover-zoom">set present</button>
 		
 		<div class="row1">
-			<object data="assets/graphic2.svg" class="graphic-left2" type="image/svg+xml"></object>
+			<object data="{% static 'конструктор стр1/assets/graphic2.svg' %}" class="graphic-left2" type="image/svg+xml"></object>
 			<p class="text-symbol1">Поиск по каталогу</p>
 		</div>
 		
@@ -24,11 +25,11 @@
 			<p class="text-plus">+7 (495) 488-72-72</p>
 			
 			<button class="btn2 hover-zoom">
-				<object data="assets/btn-icon.svg" class="heroicons-solid-chevron btn-icon2" type="image/svg+xml"></object>
+				<object data="{% static 'конструктор стр1/assets/btn-icon.svg' %}" class="heroicons-solid-chevron btn-icon2" type="image/svg+xml"></object>
 			</button>
 		</div>
 		
-		<object data="assets/graphic3.svg" class="graphic-right" type="image/svg+xml"></object>
+		<object data="{% static 'конструктор стр1/assets/graphic3.svg' %}" class="graphic-right" type="image/svg+xml"></object>
 	</div>
 	
 	<div class="col2">
@@ -39,7 +40,7 @@
 			<div class="row-bottom1">
 				<div class="row-left">
 					<div class="circle circle-yellow">
-						<object data="assets/circle/circle-heroicons1.svg" class="circle-heroicons-solid-sparkles circle-heroicons" type="image/svg+xml"></object>
+						<object data="{% static 'конструктор стр1/assets/circle/circle-heroicons1.svg' %}" class="circle-heroicons-solid-sparkles circle-heroicons" type="image/svg+xml"></object>
 					</div>
 					
 					<div class="line line-right1"></div>
@@ -49,7 +50,7 @@
 					<div class="line"></div>
 					
 					<div class="circle circle-light1">
-						<object data="assets/circle/circle-heroicons2.svg" class="circle-heroicons-solid-sparkles circle-heroicons" type="image/svg+xml"></object>
+						<object data="{% static 'конструктор стр1/assets/circle/circle-heroicons2.svg' %}" class="circle-heroicons-solid-sparkles circle-heroicons" type="image/svg+xml"></object>
 					</div>
 					
 					<div class="line"></div>
@@ -59,7 +60,7 @@
 					<div class="line"></div>
 					
 					<div class="circle circle-light2">
-						<object data="assets/circle/circle-heroicons3.svg" class="circle-heroicons-solid-sparkles circle-heroicons" type="image/svg+xml"></object>
+						<object data="{% static 'конструктор стр1/assets/circle/circle-heroicons3.svg' %}" class="circle-heroicons-solid-sparkles circle-heroicons" type="image/svg+xml"></object>
 					</div>
 				</div>
 			</div>
@@ -71,7 +72,7 @@
 				
 				<button class="btn-white hover-dark">
 					<div class="btn-white-icon circle1">
-						<object data="assets/btn-white-heroicons.svg" class="heroicons-solid-chevron btn-white-heroicons" type="image/svg+xml"></object>
+						<object data="{% static 'конструктор стр1/assets/btn-white-heroicons.svg' %}" class="heroicons-solid-chevron btn-white-heroicons" type="image/svg+xml"></object>
 					</div>
 					
 					<p class="label-symbol">Назад</p>
@@ -81,7 +82,7 @@
 					<p class="label-symbol">Далее</p>
 					
 					<div class="btn-white-right-icon circle1">
-						<object data="assets/btn-white-right-heroicons.svg" class="heroicons-solid-chevron btn-white-right-heroicons" type="image/svg+xml"></object>
+						<object data="{% static 'конструктор стр1/assets/btn-white-right-heroicons.svg' %}" class="heroicons-solid-chevron btn-white-right-heroicons" type="image/svg+xml"></object>
 					</div>
 				</button>
 			</div>
@@ -92,7 +93,7 @@
 						<div class="column col-left">
 							<button class="btn hover-bright">
 								<div class="btn-icon circle1">
-									<object data="assets/btn-icon-circle-white/btn-heroicons.svg" class="heroicons-solid-plus-a btn-heroicons" type="image/svg+xml"></object>
+									<object data="{% static 'конструктор стр1/assets/btn-icon-circle-white/btn-heroicons.svg' %}" class="heroicons-solid-plus-a btn-heroicons" type="image/svg+xml"></object>
 								</div>
 							</button>
 							
@@ -108,7 +109,7 @@
 						<div class="column col">
 							<button class="btn hover-bright">
 								<div class="btn-icon circle1">
-									<object data="assets/btn-icon-circle-white/btn-heroicons.svg" class="heroicons-solid-plus-a btn-heroicons" type="image/svg+xml"></object>
+									<object data="{% static 'конструктор стр1/assets/btn-icon-circle-white/btn-heroicons.svg' %}" class="heroicons-solid-plus-a btn-heroicons" type="image/svg+xml"></object>
 								</div>
 							</button>
 							
@@ -123,11 +124,11 @@
 						
 						<div class="row-group-right">
 							<div class="row-circle circle1">
-								<object data="assets/btn-icon-circle-white/btn-heroicons.svg" class="heroicons-solid-plus-a row-heroicons" type="image/svg+xml"></object>
+								<object data="{% static 'конструктор стр1/assets/btn-icon-circle-white/btn-heroicons.svg' %}" class="heroicons-solid-plus-a row-heroicons" type="image/svg+xml"></object>
 							</div>
 							
 							<div class="row-col">
-								<img src="assets/row-column/row-symbol.png" class="row-symbol" />
+								<img src="{% static 'конструктор стр1/assets/row-column/row-symbol.png' %}" class="row-symbol" />
 								
 								<div class="row-col-bottom">
 									<p>
@@ -144,7 +145,7 @@
 						<div class="column col-left">
 							<button class="btn hover-bright">
 								<div class="btn-icon circle1">
-									<object data="assets/btn-icon-circle-white/btn-heroicons.svg" class="heroicons-solid-plus-a btn-heroicons" type="image/svg+xml"></object>
+									<object data="{% static 'конструктор стр1/assets/btn-icon-circle-white/btn-heroicons.svg' %}" class="heroicons-solid-plus-a btn-heroicons" type="image/svg+xml"></object>
 								</div>
 							</button>
 							
@@ -160,7 +161,7 @@
 						<div class="column col">
 							<button class="btn hover-bright">
 								<div class="btn-icon circle1">
-									<object data="assets/btn-icon-circle-white/btn-heroicons.svg" class="heroicons-solid-plus-a btn-heroicons" type="image/svg+xml"></object>
+									<object data="{% static 'конструктор стр1/assets/btn-icon-circle-white/btn-heroicons.svg' %}" class="heroicons-solid-plus-a btn-heroicons" type="image/svg+xml"></object>
 								</div>
 							</button>
 							
@@ -175,11 +176,11 @@
 						
 						<div class="row-group-right">
 							<div class="row-circle circle1">
-								<object data="assets/btn-icon-circle-white/btn-heroicons.svg" class="heroicons-solid-plus-a row-heroicons" type="image/svg+xml"></object>
+								<object data="{% static 'конструктор стр1/assets/btn-icon-circle-white/btn-heroicons.svg' %}" class="heroicons-solid-plus-a row-heroicons" type="image/svg+xml"></object>
 							</div>
 							
 							<div class="row-col">
-								<img src="assets/row-column/row-symbol.png" class="row-symbol" />
+								<img src="{% static 'конструктор стр1/assets/row-column/row-symbol.png' %}" class="row-symbol" />
 								
 								<div class="row-col-bottom">
 									<p>
@@ -196,7 +197,7 @@
 						<div class="column col-left">
 							<button class="btn hover-bright">
 								<div class="btn-icon circle1">
-									<object data="assets/btn-icon-circle-white/btn-heroicons.svg" class="heroicons-solid-plus-a btn-heroicons" type="image/svg+xml"></object>
+									<object data="{% static 'конструктор стр1/assets/btn-icon-circle-white/btn-heroicons.svg' %}" class="heroicons-solid-plus-a btn-heroicons" type="image/svg+xml"></object>
 								</div>
 							</button>
 							
@@ -212,7 +213,7 @@
 						<div class="column col">
 							<button class="btn hover-bright">
 								<div class="btn-icon circle1">
-									<object data="assets/btn-icon-circle-white/btn-heroicons.svg" class="heroicons-solid-plus-a btn-heroicons" type="image/svg+xml"></object>
+									<object data="{% static 'конструктор стр1/assets/btn-icon-circle-white/btn-heroicons.svg' %}" class="heroicons-solid-plus-a btn-heroicons" type="image/svg+xml"></object>
 								</div>
 							</button>
 							
@@ -227,11 +228,11 @@
 						
 						<div class="row-group-right">
 							<div class="row-circle circle1">
-								<object data="assets/btn-icon-circle-white/btn-heroicons.svg" class="heroicons-solid-plus-a row-heroicons" type="image/svg+xml"></object>
+								<object data="{% static 'конструктор стр1/assets/btn-icon-circle-white/btn-heroicons.svg' %}" class="heroicons-solid-plus-a row-heroicons" type="image/svg+xml"></object>
 							</div>
 							
 							<div class="row-col">
-								<img src="assets/row-column/row-symbol.png" class="row-symbol" />
+								<img src="{% static 'конструктор стр1/assets/row-column/row-symbol.png' %}" class="row-symbol" />
 								
 								<div class="row-col-bottom">
 									<p>
@@ -248,7 +249,7 @@
 						<div class="column col-left">
 							<button class="btn hover-bright">
 								<div class="btn-icon circle1">
-									<object data="assets/btn-icon-circle-white/btn-heroicons.svg" class="heroicons-solid-plus-a btn-heroicons" type="image/svg+xml"></object>
+									<object data="{% static 'конструктор стр1/assets/btn-icon-circle-white/btn-heroicons.svg' %}" class="heroicons-solid-plus-a btn-heroicons" type="image/svg+xml"></object>
 								</div>
 							</button>
 							
@@ -264,7 +265,7 @@
 						<div class="column col">
 							<button class="btn hover-bright">
 								<div class="btn-icon circle1">
-									<object data="assets/btn-icon-circle-white/btn-heroicons.svg" class="heroicons-solid-plus-a btn-heroicons" type="image/svg+xml"></object>
+									<object data="{% static 'конструктор стр1/assets/btn-icon-circle-white/btn-heroicons.svg' %}" class="heroicons-solid-plus-a btn-heroicons" type="image/svg+xml"></object>
 								</div>
 							</button>
 							
@@ -279,11 +280,11 @@
 						
 						<div class="row-group-right">
 							<div class="row-circle circle1">
-								<object data="assets/btn-icon-circle-white/btn-heroicons.svg" class="heroicons-solid-plus-a row-heroicons" type="image/svg+xml"></object>
+								<object data="{% static 'конструктор стр1/assets/btn-icon-circle-white/btn-heroicons.svg' %}" class="heroicons-solid-plus-a row-heroicons" type="image/svg+xml"></object>
 							</div>
 							
 							<div class="row-col">
-								<img src="assets/row-column/row-symbol.png" class="row-symbol" />
+								<img src="{% static 'конструктор стр1/assets/row-column/row-symbol.png' %}" class="row-symbol" />
 								
 								<div class="row-col-bottom">
 									<p>
@@ -301,7 +302,7 @@
 					<p class="text-symbol2">Показать еще</p>
 					
 					<div class="circle-black-right">
-						<object data="assets/btn-icon-circle-white/btn-heroicons.svg" class="heroicons-solid-plus-b heroicons-solid-plus1" type="image/svg+xml"></object>
+						<object data="{% static 'конструктор стр1/assets/btn-icon-circle-white/btn-heroicons.svg' %}" class="heroicons-solid-plus-b heroicons-solid-plus1" type="image/svg+xml"></object>
 					</div>
 				</div>
 			</div>
@@ -342,11 +343,11 @@
 			
 			<div class="footer-nav-items1">
 				<div class="footer-circle">
-					<object data="assets/footer-graphic1.svg" class="footer-graphic1" type="image/svg+xml"></object>
+					<object data="{% static 'конструктор стр1/assets/footer-graphic1.svg' %}" class="footer-graphic1" type="image/svg+xml"></object>
 				</div>
 				
-				<object data="assets/footer-graphic2.svg" class="footer-graphic footer-graphic2" type="image/svg+xml"></object>
-				<object data="assets/footer-graphic3.svg" class="footer-graphic footer-graphic-right" type="image/svg+xml"></object>
+				<object data="{% static 'конструктор стр1/assets/footer-graphic2.svg' %}" class="footer-graphic footer-graphic2" type="image/svg+xml"></object>
+				<object data="{% static 'конструктор стр1/assets/footer-graphic3.svg' %}" class="footer-graphic footer-graphic-right" type="image/svg+xml"></object>
 			</div>
 		</div>
 		

--- a/templates/mainpage.html
+++ b/templates/mainpage.html
@@ -1,12 +1,13 @@
+{% load static %}
 <!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 	<link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap" rel="stylesheet">
-	<link rel="stylesheet" href="css/reset.css" />
-	<link rel="stylesheet" href="css/global.css" />
-	<link rel="stylesheet" href="css/mainpage.css" />
+	<link rel="stylesheet" href="{% static 'главная страница/css/reset.css' %}" />
+	<link rel="stylesheet" href="{% static 'главная страница/css/global.css' %}" />
+	<link rel="stylesheet" href="{% static 'главная страница/css/mainpage.css' %}" />
 
 </head>
 
@@ -15,11 +16,11 @@
 		<div class="mainpage-col2">
 			<header class="header">
 				<div class="header-row1">
-					<object data="assets/header-graphic1.svg" class="header-graphic-left1" type="image/svg+xml"></object>
+					<object data="{% static 'главная страница/assets/header-graphic1.svg' %}" class="header-graphic-left1" type="image/svg+xml"></object>
 					<button class="header-btn-set-present hover-zoom">set present</button>
 					
 					<div class="header-row2">
-						<object data="assets/header-graphic2.svg" class="header-graphic-left2" type="image/svg+xml"></object>
+						<object data="{% static 'главная страница/assets/header-graphic2.svg' %}" class="header-graphic-left2" type="image/svg+xml"></object>
 						<p class="header-text-symbol">Поиск по каталогу</p>
 					</div>
 					
@@ -27,11 +28,11 @@
 						<p class="header-text-plus">+7 (495) 488-72-72</p>
 						
 						<button class="btn hover-zoom">
-							<object data="assets/btn-icon.svg" class="btn-icon-heros-outline-phone btn-icon" type="image/svg+xml"></object>
+							<object data="{% static 'главная страница/assets/btn-icon.svg' %}" class="btn-icon-heros-outline-phone btn-icon" type="image/svg+xml"></object>
 						</button>
 					</div>
 					
-					<object data="assets/header-graphic3.svg" class="header-graphic-right" type="image/svg+xml"></object>
+					<object data="{% static 'главная страница/assets/header-graphic3.svg' %}" class="header-graphic-right" type="image/svg+xml"></object>
 				</div>
 				
 				<div class="header-col1">
@@ -47,7 +48,7 @@
 				</div>
 				
 				<div class="header-col2">
-					<img src="assets/header-mask-group.png" class="header-mask-group" />
+					<img src="{% static 'главная страница/assets/header-mask-group.png' %}" class="header-mask-group" />
 				</div>
 			</header>
 			
@@ -68,7 +69,7 @@
 						<h2 class="mainpage-subtitle-symbol2">Новогодние наборы</h2>
 						
 						<div class="group-a">
-							<img src="assets/group/group-symbol1.png" class="group-symbol1 input" />
+							<img src="{% static 'главная страница/assets/group/group-symbol1.png' %}" class="group-symbol1 input" />
 							<div class="group-rect1 card"></div>
 						</div>
 					</div>
@@ -77,7 +78,7 @@
 						<h2 class="mainpage-subtitle-symbol3">Съедобные наборы</h2>
 						
 						<div class="group-a">
-							<img src="assets/group/group-symbol2.png" class="group-symbol1 input" />
+							<img src="{% static 'главная страница/assets/group/group-symbol2.png' %}" class="group-symbol1 input" />
 							<div class="group-rect1 card"></div>
 						</div>
 					</div>
@@ -86,7 +87,7 @@
 						<h2 class="mainpage-subtitle-symbol4">Офисная атрибутика</h2>
 						
 						<div class="group-b">
-							<img src="assets/group/group-symbol3.png" class="group-symbol2 input" />
+							<img src="{% static 'главная страница/assets/group/group-symbol3.png' %}" class="group-symbol2 input" />
 							<div class="group-rect2 card"></div>
 						</div>
 					</div>
@@ -95,7 +96,7 @@
 						<h2 class="group-subtitle">Для женщин</h2>
 						
 						<div class="group-b">
-							<img src="assets/group/group-symbol4.png" class="group-symbol2 input" />
+							<img src="{% static 'главная страница/assets/group/group-symbol4.png' %}" class="group-symbol2 input" />
 							<div class="group-rect2 card"></div>
 						</div>
 					</div>
@@ -104,7 +105,7 @@
 						<h2 class="group-subtitle">Для мужчин</h2>
 						
 						<div class="group-b">
-							<img src="assets/group/group-symbol5.png" class="group-symbol2 input" />
+							<img src="{% static 'главная страница/assets/group/group-symbol5.png' %}" class="group-symbol2 input" />
 							<div class="group-rect2 card"></div>
 						</div>
 					</div>
@@ -121,7 +122,7 @@
 					
 					<div class="column-b col2">
 						<h1 class="column-title">1</h1>
-						<img src="assets/column/column-symbol1.png" class="column-symbol input" />
+						<img src="{% static 'главная страница/assets/column/column-symbol1.png' %}" class="column-symbol input" />
 						
 						<div class="column-a col-bottom">
 							<h2 class="subtitle-symbol">Упаковка</h2>
@@ -133,7 +134,7 @@
 					
 					<div class="column-b col3">
 						<h1 class="column-title">2</h1>
-						<img src="assets/column/column-symbol2.png" class="column-symbol input" />
+						<img src="{% static 'главная страница/assets/column/column-symbol2.png' %}" class="column-symbol input" />
 						
 						<div class="column-a col-bottom">
 							<h2 class="subtitle-symbol">Наполнение</h2>
@@ -145,7 +146,7 @@
 					
 					<div class="column-b col4">
 						<h1 class="column-title">3</h1>
-						<img src="assets/column/column-symbol3.png" class="column-symbol input" />
+						<img src="{% static 'главная страница/assets/column/column-symbol3.png' %}" class="column-symbol input" />
 						
 						<div class="column-a col-bottom">
 							<h2 class="subtitle-symbol">Оформление</h2>
@@ -169,11 +170,11 @@
 				
 				<div class="footer-nav-items1">
 					<div class="footer-circle">
-						<object data="assets/footer-graphic1.svg" class="footer-graphic1" type="image/svg+xml"></object>
+						<object data="{% static 'главная страница/assets/footer-graphic1.svg' %}" class="footer-graphic1" type="image/svg+xml"></object>
 					</div>
 					
-					<object data="assets/footer-graphic2.svg" class="footer-graphic footer-graphic2" type="image/svg+xml"></object>
-					<object data="assets/footer-graphic3.svg" class="footer-graphic footer-graphic-right" type="image/svg+xml"></object>
+					<object data="{% static 'главная страница/assets/footer-graphic2.svg' %}" class="footer-graphic footer-graphic2" type="image/svg+xml"></object>
+					<object data="{% static 'главная страница/assets/footer-graphic3.svg' %}" class="footer-graphic footer-graphic-right" type="image/svg+xml"></object>
 				</div>
 			</div>
 			

--- a/templates/product_detail.html
+++ b/templates/product_detail.html
@@ -1,12 +1,13 @@
+{% load static %}
 <!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 	<link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap" rel="stylesheet">
-	<link rel="stylesheet" href="css/reset.css" />
-	<link rel="stylesheet" href="css/global.css" />
-	<link rel="stylesheet" href="css/symbol.css" />
+	<link rel="stylesheet" href="{% static 'страница товара/css/reset.css' %}" />
+	<link rel="stylesheet" href="{% static 'страница товара/css/global.css' %}" />
+	<link rel="stylesheet" href="{% static 'страница товара/css/symbol.css' %}" />
 
 </head>
 
@@ -14,11 +15,11 @@
 	<div class="col1">
 		<div class="col2">
 			<div class="row-top1">
-				<object data="assets/graphic1.svg" class="graphic-left1" type="image/svg+xml"></object>
+				<object data="{% static 'страница товара/assets/graphic1.svg' %}" class="graphic-left1" type="image/svg+xml"></object>
 				<h2 class="subtitle-set-present">set present</h2>
 				
 				<div class="row1">
-					<object data="assets/graphic2.svg" class="graphic-left2" type="image/svg+xml"></object>
+					<object data="{% static 'страница товара/assets/graphic2.svg' %}" class="graphic-left2" type="image/svg+xml"></object>
 					<p class="text-symbol1">Поиск по каталогу</p>
 				</div>
 				
@@ -26,16 +27,16 @@
 					<p class="text-plus">+7 (495) 488-72-72</p>
 					
 					<div class="group2">
-						<object data="assets/heroicons-outline-phone.svg" class="heroicons-solid-sparkles heroicons-outline-phone" type="image/svg+xml"></object>
+						<object data="{% static 'страница товара/assets/heroicons-outline-phone.svg' %}" class="heroicons-solid-sparkles heroicons-outline-phone" type="image/svg+xml"></object>
 					</div>
 				</div>
 				
-				<object data="assets/graphic3.svg" class="graphic-right" type="image/svg+xml"></object>
+				<object data="{% static 'страница товара/assets/graphic3.svg' %}" class="graphic-right" type="image/svg+xml"></object>
 			</div>
 			
 			<div class="col3">
 				<div class="row-top2">
-					<img src="assets/symbol.png" class="symbol2" />
+					<img src="{% static 'страница товара/assets/symbol.png' %}" class="symbol2" />
 					
 					<div class="col-right">
 						<h1 class="title title1">Подарочный набор «Улыбайся чаще»</h1>
@@ -46,7 +47,7 @@
 								<p class="text-symbol">В корзину</p>
 								
 								<div class="card-left-circle circle-white">
-									<object data="assets/card-left-heroicons.svg" class="heroicons-solid-sparkles card-left-heroicons" type="image/svg+xml"></object>
+									<object data="{% static 'страница товара/assets/card-left-heroicons.svg' %}" class="heroicons-solid-sparkles card-left-heroicons" type="image/svg+xml"></object>
 								</div>
 							</div>
 							
@@ -54,7 +55,7 @@
 								<p class="text-symbol">В избранное</p>
 								
 								<div class="card-circle circle-white">
-									<object data="assets/card-circle-white/card-heroicons1.svg" class="heroicons-solid-sparkles card-heroicons1" type="image/svg+xml"></object>
+									<object data="{% static 'страница товара/assets/card-circle-white/card-heroicons1.svg' %}" class="heroicons-solid-sparkles card-heroicons1" type="image/svg+xml"></object>
 								</div>
 							</div>
 							
@@ -62,7 +63,7 @@
 								<p class="text-symbol">Конструктор</p>
 								
 								<div class="card-circle circle-white">
-									<object data="assets/card-circle-white/card-heroicons2.svg" class="heroicons-solid-sparkles card-heroicons1" type="image/svg+xml"></object>
+									<object data="{% static 'страница товара/assets/card-circle-white/card-heroicons2.svg' %}" class="heroicons-solid-sparkles card-heroicons1" type="image/svg+xml"></object>
 								</div>
 							</div>
 						</div>
@@ -70,17 +71,17 @@
 						<div class="col-bottom1">
 							<div class="row row3">
 								<p>Наполнение</p>
-								<object data="assets/row/row-heroicons.svg" class="row-heroicons-solid-chevron row-heroicons" type="image/svg+xml"></object>
+								<object data="{% static 'страница товара/assets/row/row-heroicons.svg' %}" class="row-heroicons-solid-chevron row-heroicons" type="image/svg+xml"></object>
 							</div>
 							
 							<div class="row row4">
 								<p>Доставка</p>
-								<object data="assets/row/row-heroicons.svg" class="row-heroicons-solid-chevron row-heroicons" type="image/svg+xml"></object>
+								<object data="{% static 'страница товара/assets/row/row-heroicons.svg' %}" class="row-heroicons-solid-chevron row-heroicons" type="image/svg+xml"></object>
 							</div>
 							
 							<div class="row row5">
 								<p>Оплата</p>
-								<object data="assets/row/row-heroicons.svg" class="row-heroicons-solid-chevron row-heroicons" type="image/svg+xml"></object>
+								<object data="{% static 'страница товара/assets/row/row-heroicons.svg' %}" class="row-heroicons-solid-chevron row-heroicons" type="image/svg+xml"></object>
 							</div>
 						</div>
 					</div>
@@ -93,11 +94,11 @@
 						<div class="column col4">
 							<div class="card1">
 								<div class="card-circle-white-top circle-white">
-									<object data="assets/card-circle-white/card-heroicons3.svg" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
+									<object data="{% static 'страница товара/assets/card-circle-white/card-heroicons3.svg' %}" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
 								</div>
 								
 								<div class="card-circle-white-bottom">
-									<object data="assets/card-circle-white/card-heroicons4.svg" class="card-heroicons-solid-heart card-heroicons3" type="image/svg+xml"></object>
+									<object data="{% static 'страница товара/assets/card-circle-white/card-heroicons4.svg' %}" class="card-heroicons-solid-heart card-heroicons3" type="image/svg+xml"></object>
 								</div>
 							</div>
 							
@@ -113,11 +114,11 @@
 						<div class="column col5">
 							<div class="card1">
 								<div class="card-circle-white-top circle-white">
-									<object data="assets/card-circle-white/card-heroicons3.svg" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
+									<object data="{% static 'страница товара/assets/card-circle-white/card-heroicons3.svg' %}" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
 								</div>
 								
 								<div class="card-circle-white-bottom">
-									<object data="assets/card-circle-white/card-heroicons4.svg" class="card-heroicons-solid-heart card-heroicons3" type="image/svg+xml"></object>
+									<object data="{% static 'страница товара/assets/card-circle-white/card-heroicons4.svg' %}" class="card-heroicons-solid-heart card-heroicons3" type="image/svg+xml"></object>
 								</div>
 							</div>
 							
@@ -133,11 +134,11 @@
 						<div class="column col6">
 							<div class="card1">
 								<div class="card-circle-white-top circle-white">
-									<object data="assets/card-circle-white/card-heroicons3.svg" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
+									<object data="{% static 'страница товара/assets/card-circle-white/card-heroicons3.svg' %}" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
 								</div>
 								
 								<div class="card-circle-white-bottom">
-									<object data="assets/card-circle-white/card-heroicons4.svg" class="card-heroicons-solid-heart card-heroicons3" type="image/svg+xml"></object>
+									<object data="{% static 'страница товара/assets/card-circle-white/card-heroicons4.svg' %}" class="card-heroicons-solid-heart card-heroicons3" type="image/svg+xml"></object>
 								</div>
 							</div>
 							
@@ -153,11 +154,11 @@
 						<div class="column col7">
 							<div class="card1">
 								<div class="card-circle-white-top circle-white">
-									<object data="assets/card-circle-white/card-heroicons3.svg" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
+									<object data="{% static 'страница товара/assets/card-circle-white/card-heroicons3.svg' %}" class="card-heroicons-solid-heart card-heroicons2" type="image/svg+xml"></object>
 								</div>
 								
 								<div class="card-circle-white-bottom">
-									<object data="assets/card-circle-white/card-heroicons4.svg" class="card-heroicons-solid-heart card-heroicons3" type="image/svg+xml"></object>
+									<object data="{% static 'страница товара/assets/card-circle-white/card-heroicons4.svg' %}" class="card-heroicons-solid-heart card-heroicons3" type="image/svg+xml"></object>
 								</div>
 							</div>
 							
@@ -180,11 +181,11 @@
 				
 				<div class="footer-nav-items1">
 					<div class="footer-circle circle-white">
-						<object data="assets/footer-graphic1.svg" class="footer-graphic1" type="image/svg+xml"></object>
+						<object data="{% static 'страница товара/assets/footer-graphic1.svg' %}" class="footer-graphic1" type="image/svg+xml"></object>
 					</div>
 					
-					<object data="assets/footer-graphic2.svg" class="footer-graphic footer-graphic2" type="image/svg+xml"></object>
-					<object data="assets/footer-graphic3.svg" class="footer-graphic footer-graphic-right" type="image/svg+xml"></object>
+					<object data="{% static 'страница товара/assets/footer-graphic2.svg' %}" class="footer-graphic footer-graphic2" type="image/svg+xml"></object>
+					<object data="{% static 'страница товара/assets/footer-graphic3.svg' %}" class="footer-graphic footer-graphic-right" type="image/svg+xml"></object>
 				</div>
 			</div>
 			


### PR DESCRIPTION
## Summary
- connect static subfolders for catalog, constructor, main page and product page
- ignore Python bytecode

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684ff7f8921c832a80717ccf860d58a9