### PR TITLE
Add cart order creation

### DIFF
--- a/shop/templatetags/cart_tags.py
+++ b/shop/templatetags/cart_tags.py
@@ -10,3 +10,9 @@ def multiply(value1, value2):
 def sum_total(cart_items):
     total = sum(item.quantity * item.product_id.price for item in cart_items)
     return total
+
+
+@register.filter
+def sum_quantity(cart_items):
+    """Return the total quantity of products in the cart."""
+    return sum(item.quantity for item in cart_items)

--- a/templates/cart.html
+++ b/templates/cart.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% load static cart_tags %}
 <!DOCTYPE html>
 <html>
 <head>
@@ -12,7 +12,20 @@
 </head>
 
 <body>
-	<div class="col1">
+{% if order_created %}
+<div id="modal" style="position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.5);display:flex;align-items:center;justify-content:center;">
+    <div style="background:white;padding:20px;border-radius:8px;text-align:center;">
+        <p>Спасибо за заказ, с вами свяжутся</p>
+        <button id="close-modal">Закрыть</button>
+    </div>
+</div>
+<script>
+document.getElementById('close-modal').addEventListener('click', function() {
+    document.getElementById('modal').style.display = 'none';
+});
+</script>
+{% endif %}
+        <div class="col1">
 		<div class="row-top">
 			<object data="{% static 'корзина/assets/graphic1.svg' %}" class="graphic-left1" type="image/svg+xml"></object>
 			<h2 class="subtitle-set-present">set present</h2>
@@ -37,149 +50,69 @@
 			<h1 class="title-symbol">Корзина</h1>
 			
 			<div class="row2">
-				<div class="col3">
-					<div class="row row3">
-						<div class="row-row">
-							<img src="{% static 'корзина/assets/row-row/row-symbol.png' %}" class="row-symbol" />
-							
-							<div class="row-col">
-								<h2 class="row-subtitle">
-									Подарочный набор<br />
-									«Антрацит»
-								</h2>
-								
-								<div class="row-row-bottom">
-									<button class="row-btn hover-bright">8 775 ₽</button>
-									
-									<button class="btn-light-right hover-dark">
-										<object data="{% static 'корзина/assets/btn-light/btn-light-icon-heros.svg' %}" class="btn-light-icon-heros-solid-plus btn-light-icon-heros1" type="image/svg+xml"></object>
-										<p>1 шт</p>
-										
-										<div class="btn-light-icon-heros2">
-											<div class="btn-light-line"></div>
-										</div>
-									</button>
-								</div>
-							</div>
-						</div>
-						
-						<object data="{% static 'корзина/assets/row/row-heroicons.svg' %}" class="row-heroicons-solid-x-mark row-heroicons" type="image/svg+xml"></object>
-					</div>
-					
-					<div class="row row4">
-						<div class="row-row">
-							<img src="{% static 'корзина/assets/row-row/row-symbol.png' %}" class="row-symbol" />
-							
-							<div class="row-col">
-								<h2 class="row-subtitle">
-									Подарочный набор<br />
-									«Антрацит»
-								</h2>
-								
-								<div class="row-row-bottom">
-									<button class="row-btn hover-bright">8 775 ₽</button>
-									
-									<button class="btn-light-right hover-dark">
-										<object data="{% static 'корзина/assets/btn-light/btn-light-icon-heros.svg' %}" class="btn-light-icon-heros-solid-plus btn-light-icon-heros1" type="image/svg+xml"></object>
-										<p>1 шт</p>
-										
-										<div class="btn-light-icon-heros2">
-											<div class="btn-light-line"></div>
-										</div>
-									</button>
-								</div>
-							</div>
-						</div>
-						
-						<object data="{% static 'корзина/assets/row/row-heroicons.svg' %}" class="row-heroicons-solid-x-mark row-heroicons" type="image/svg+xml"></object>
-					</div>
-					
-					<div class="row row5">
-						<div class="row-row">
-							<img src="{% static 'корзина/assets/row-row/row-symbol.png' %}" class="row-symbol" />
-							
-							<div class="row-col">
-								<h2 class="row-subtitle">
-									Подарочный набор<br />
-									«Антрацит»
-								</h2>
-								
-								<div class="row-row-bottom">
-									<button class="row-btn hover-bright">8 775 ₽</button>
-									
-									<button class="btn-light-right hover-dark">
-										<object data="{% static 'корзина/assets/btn-light/btn-light-icon-heros.svg' %}" class="btn-light-icon-heros-solid-plus btn-light-icon-heros1" type="image/svg+xml"></object>
-										<p>1 шт</p>
-										
-										<div class="btn-light-icon-heros2">
-											<div class="btn-light-line"></div>
-										</div>
-									</button>
-								</div>
-							</div>
-						</div>
-						
-						<object data="{% static 'корзина/assets/row/row-heroicons.svg' %}" class="row-heroicons-solid-x-mark row-heroicons" type="image/svg+xml"></object>
-					</div>
-					
-					<div class="row row6">
-						<div class="row-row">
-							<img src="{% static 'корзина/assets/row-row/row-symbol.png' %}" class="row-symbol" />
-							
-							<div class="row-col">
-								<h2 class="row-subtitle">
-									Подарочный набор<br />
-									«Антрацит»
-								</h2>
-								
-								<div class="row-row-bottom">
-									<button class="row-btn hover-bright">8 775 ₽</button>
-									
-									<button class="btn-light-right hover-dark">
-										<object data="{% static 'корзина/assets/btn-light/btn-light-icon-heros.svg' %}" class="btn-light-icon-heros-solid-plus btn-light-icon-heros1" type="image/svg+xml"></object>
-										<p>1 шт</p>
-										
-										<div class="btn-light-icon-heros2">
-											<div class="btn-light-line"></div>
-										</div>
-									</button>
-								</div>
-							</div>
-						</div>
-						
-						<object data="{% static 'корзина/assets/row/row-heroicons.svg' %}" class="row-heroicons-solid-x-mark row-heroicons" type="image/svg+xml"></object>
-					</div>
-				</div>
+                                <div class="col3">
+                                        {% if cart_items %}
+                                                {% for item in cart_items %}
+                                                <div class="row">
+                                                        <div class="row-row">
+                                                                <img src="{% static 'корзина/assets/row-row/row-symbol.png' %}" class="row-symbol" />
+
+                                                                <div class="row-col">
+                                                                        <h2 class="row-subtitle">{{ item.product_id.name }}</h2>
+
+                                                                        <div class="row-row-bottom">
+                                                                                <button class="row-btn hover-bright">{{ item.product_id.price }} ₽</button>
+
+                                                                                <button class="btn-light-right hover-dark">
+                                                                                        <object data="{% static 'корзина/assets/btn-light/btn-light-icon-heros.svg' %}" class="btn-light-icon-heros-solid-plus btn-light-icon-heros1" type="image/svg+xml"></object>
+                                                                                        <p>{{ item.quantity }} шт</p>
+
+                                                                                        <div class="btn-light-icon-heros2">
+                                                                                                <div class="btn-light-line"></div>
+                                                                                        </div>
+                                                                                </button>
+                                                                        </div>
+                                                                </div>
+                                                        </div>
+
+                                                        <object data="{% static 'корзина/assets/row/row-heroicons.svg' %}" class="row-heroicons-solid-x-mark row-heroicons" type="image/svg+xml"></object>
+                                                </div>
+                                                {% endfor %}
+                                        {% else %}
+                                                <p>Корзина пуста.</p>
+                                        {% endif %}
+                                </div>
 				
-				<div class="col-right">
-					<div class="card">
-						<div class="card-col-top">
-							<input class="card-input-symbol" value="Ваше имя" />
-							<input class="card-input-symbol" value="Номер телефона" />
-							<input class="card-input-symbol" value="Email" />
-						</div>
-						
-						<div class="card-col">
-							<div class="card-row-top">
-								<p class="card-text-left">Товары 5 шт.</p>
-								<div class="card-line1"></div>
-								<p class="card-text-right">
-14 550 ₽</p>
-							</div>
-							
-							<div class="card-row-bottom">
-								<h2 class="card-subtitle-left">Итого</h2>
-								<div class="card-line2"></div>
-								<h2 class="card-subtitle-right">
-14 550 ₽</h2>
-							</div>
-						</div>
-						
-						<button class="card-btn-symbol hover-bright">Оформить заказ</button>
-						<p class="card-text-bottom">
-							Нажимая на кнопку «Оформить заказ», вы соглашаетесь c <a class="link" href="#">политикой конфиденциальности</a> и условиями обработ­ки персональных данных.
-						</p>
-					</div>
+                                <div class="col-right">
+                                        <div class="card">
+                                                <form method="post">
+                                                        {% csrf_token %}
+                                                        <div class="card-col-top">
+                                                                <input name="name" class="card-input-symbol" placeholder="Ваше имя" />
+                                                                <input name="phone" class="card-input-symbol" placeholder="Номер телефона" />
+                                                                <input name="email" class="card-input-symbol" placeholder="Email" />
+                                                        </div>
+
+                                                        <div class="card-col">
+                                                                <div class="card-row-top">
+                                                                        <p class="card-text-left">Товары {{ cart_items|sum_quantity }} шт.</p>
+                                                                        <div class="card-line1"></div>
+                                                                        <p class="card-text-right">{{ cart_items|sum_total }} ₽</p>
+                                                                </div>
+
+                                                                <div class="card-row-bottom">
+                                                                        <h2 class="card-subtitle-left">Итого</h2>
+                                                                        <div class="card-line2"></div>
+                                                                        <h2 class="card-subtitle-right">{{ cart_items|sum_total }} ₽</h2>
+                                                                </div>
+                                                        </div>
+
+                                                        <button type="submit" class="card-btn-symbol hover-bright">Оформить заказ</button>
+                                                        <p class="card-text-bottom">
+                                                                Нажимая на кнопку «Оформить заказ», вы соглашаетесь c <a class="link" href="#">политикой конфиденциальности</a> и условиями обработ­ки персональных данных.
+                                                        </p>
+                                                </form>
+                                        </div>
 					
 					<div class="row-bottom">
 						<img src="{% static 'корзина/assets/symbol.png' %}" class="symbol2" />


### PR DESCRIPTION
## Summary
- enable order creation directly from `cart.html`
- add total quantity filter and show cart items dynamically
- display confirmation modal after order submission

## Testing
- `python3 manage.py check`
- `python3 manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68500bb35c5c832a8e99f99d305128df