### PR TITLE
Fix cart ordering flow

### DIFF
--- a/shop/models.py
+++ b/shop/models.py
@@ -21,7 +21,8 @@ class Category(models.Model):
     id = models.AutoField(primary_key=True)
     name = models.CharField(max_length=255)
 
-    def str(self):
+    def __str__(self):
+        """Return category name for admin and debugging."""
         return self.name
 
 

--- a/shop/views.py
+++ b/shop/views.py
@@ -35,27 +35,14 @@ def add_to_cart(request, product_id):
 
 @login_required(login_url='auth')
 def view_cart(request):
-    cart = get_object_or_404(Cart, user_id=request.user)
-    cart_items = CartItem.objects.filter(cart_id=cart)
+    """Display the cart and handle order creation.
 
-    if request.method == 'POST':
-        form = OrderForm(request.POST)
-        if form.is_valid() and cart_items.exists():
-            order = form.save(commit=False)
-            if request.user.is_authenticated:
-                order.user_id = request.user
-            order.save()
-            for item in cart_items:
-                OrderItem.objects.create(
-                    order_id=order,
-                    product_id=item.product_id,
-                    quantity=item.quantity,
-                    price=item.product_id.price,
-                )
-            cart_items.delete()
-            return redirect('catalog')
-        
-    return render(request, 'cart.html', {'cart_items': cart_items})
+    This view mirrors the logic used in :func:`cart`.  It is kept for
+    backwards compatibility with existing URLs that redirect here after
+    adding items to the cart.
+    """
+
+    return cart(request)
 
 
 @login_required(login_url='auth')


### PR DESCRIPTION
## Summary
- reuse the `cart` logic inside `view_cart`
- implement `__str__` for `Category`

## Testing
- `python manage.py check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850123bd760832aadf82c3941635459